### PR TITLE
use Ruby 1.9+ hash syntax, remove unneeded #to_s calls

### DIFF
--- a/lib/hulse/house_vote.rb
+++ b/lib/hulse/house_vote.rb
@@ -1,21 +1,21 @@
 module Hulse
   class HouseVote
-    
+
     attr_reader :majority, :congress, :session, :chamber, :vote_number, :bill_number, :question, :vote_type, :vote_result, :vote_timestamp, :description,
     :party_summary, :vote_count, :members, :amendment_number, :amendment_author
-    
+
     def initialize(params={})
       params.each_pair do |k,v|
         instance_variable_set("@#{k}", v)
       end
-    end    
+    end
 
     def self.find(year, vote)
-      url = "http://clerk.house.gov/evs/#{year.to_s}/roll#{vote}.xml"
+      url = "http://clerk.house.gov/evs/#{year}/roll#{vote}.xml"
       response = HTTParty.get(url)
       self.create_from_vote(response.parsed_response['rollcall_vote'])
     end
-    
+
     def self.create_from_vote(response)
       party_totals = []
       response['vote_metadata']['vote_totals']['totals_by_party'].each do |p|
@@ -29,22 +29,22 @@ module Hulse
         m['legislator']['vote'] = m['vote']
         members << m['legislator'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
       end
-      self.new(:majority => response['vote_metadata']['majority'],
-        :congress => response['vote_metadata']['congress'].to_i,
-        :session => response['vote_metadata']['session'],
-        :chamber => response['vote_metadata']['chamber'],
-        :vote_number => response['vote_metadata']['rollcall_num'].to_i,
-        :bill_number => response['vote_metadata']['legis_num'],
-        :question => response['vote_metadata']['vote_question'],
-        :amendment_number => response['vote_metadata']['amendment_num'],
-        :amendment_author => response['vote_metadata']['amendment_author'],
-        :vote_type => response['vote_metadata']['vote_type'],
-        :vote_result => response['vote_metadata']['vote_result'],
-        :vote_timestamp => DateTime.parse(response['vote_metadata']['action_date'] + ' ' + response['vote_metadata']['action_time']['time_etz']),
-        :description => response['vote_metadata']['vote_desc'],
-        :party_summary => party_totals,
-        :vote_count => response['vote_metadata']['vote_totals']['totals_by_vote'].reject{|k,v| k == 'total_stub'}.inject({}){|memo,(k,v)| memo[k.to_sym] = v.to_i; memo},
-        :members => members)
+      self.new(majority: response['vote_metadata']['majority'],
+        congress: response['vote_metadata']['congress'].to_i,
+        session: response['vote_metadata']['session'],
+        chamber: response['vote_metadata']['chamber'],
+        vote_number: response['vote_metadata']['rollcall_num'].to_i,
+        bill_number: response['vote_metadata']['legis_num'],
+        question: response['vote_metadata']['vote_question'],
+        amendment_number: response['vote_metadata']['amendment_num'],
+        amendment_author: response['vote_metadata']['amendment_author'],
+        vote_type: response['vote_metadata']['vote_type'],
+        vote_result: response['vote_metadata']['vote_result'],
+        vote_timestamp: DateTime.parse(response['vote_metadata']['action_date'] + ' ' + response['vote_metadata']['action_time']['time_etz']),
+        description: response['vote_metadata']['vote_desc'],
+        party_summary: party_totals,
+        vote_count: response['vote_metadata']['vote_totals']['totals_by_vote'].reject{|k,v| k == 'total_stub'}.inject({}){|memo,(k,v)| memo[k.to_sym] = v.to_i; memo},
+        members: members)
       end
   end
 end

--- a/lib/hulse/senate_vote.rb
+++ b/lib/hulse/senate_vote.rb
@@ -1,49 +1,49 @@
 module Hulse
   class SenateVote
-    
-    attr_reader :congress, :session, :year, :vote_number, :vote_timestamp, :updated_at, :vote_question_text, :vote_document_text, 
+
+    attr_reader :congress, :session, :year, :vote_number, :vote_timestamp, :updated_at, :vote_question_text, :vote_document_text,
     :vote_result_text, :question, :vote_title, :majority_requirement, :vote_result, :document, :amendment, :vote_count, :tie_breaker, :members
-    
+
     def initialize(params={})
       params.each_pair do |k,v|
         instance_variable_set("@#{k}", v)
       end
     end
-    
+
     def self.find(year, vote)
       # TODO: need to special-case 2013 votes from 112th congress, 2nd session
       congress, session = Hulse::Utils.convert_year_to_congress_and_session(year)
-      url = "http://www.senate.gov/legislative/LIS/roll_call_votes/vote#{congress.to_s}#{session.to_s}/vote_#{congress.to_s}_#{session.to_s}_#{vote.to_s.rjust(5,"0")}.xml"
+      url = "http://www.senate.gov/legislative/LIS/roll_call_votes/vote#{congress}#{session}/vote_#{congress}_#{session}_#{vote.to_s.rjust(5,"0")}.xml"
       response = HTTParty.get(url)
       self.create_from_vote(response.parsed_response['roll_call_vote'])
     end
-    
+
     def self.create_from_vote(response)
       members = []
       response['members']['member'].each do |m|
         members << m.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
       end
-      self.new(:congress => response['congress'].to_i,
-        :session => response['session'].to_i,
-        :year => response['congress_year'].to_i,
-        :vote_number => response['vote_number'].to_i,
-        :vote_timestamp => DateTime.parse(response['vote_date']),
-        :updated_at => DateTime.parse(response['modify_date']),
-        :vote_question_text => response['vote_question_text'],
-        :vote_document_text => response['vote_document_text'],
-        :vote_result_text => response['vote_result_text'],
-        :question => response['question'],
-        :vote_title => response['vote_title'],
-        :majority_requirement => response['majority_requirement'],
-        :vote_result => response['vote_result'],
-        :document => response['document'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
-        :amendment => response['amendment'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
-        :vote_count => response['count'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
-        :tie_breaker => response['tie_breaker'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
-        :members => members
-      )  
+      self.new(congress: response['congress'].to_i,
+        session: response['session'].to_i,
+        year: response['congress_year'].to_i,
+        vote_number: response['vote_number'].to_i,
+        vote_timestamp: DateTime.parse(response['vote_date']),
+        updated_at: DateTime.parse(response['modify_date']),
+        vote_question_text: response['vote_question_text'],
+        vote_document_text: response['vote_document_text'],
+        vote_result_text: response['vote_result_text'],
+        question: response['question'],
+        vote_title: response['vote_title'],
+        majority_requirement: response['majority_requirement'],
+        vote_result: response['vote_result'],
+        document: response['document'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
+        amendment: response['amendment'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
+        vote_count: response['count'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
+        tie_breaker: response['tie_breaker'].inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo},
+        members: members
+      )
     end
-    
-    
+
+
   end
 end


### PR DESCRIPTION
Ruby 1.8 is EOLed, and the README says it's developed on 1.9, so this switches to 1.9+ hash syntax with symbols.

It also removes a few unneeded #to_s calls. Ruby's string interpolation with braces does this for you implicitly. It's actually also safer than +-based interpolation, which will throw errors if you haven't already #to_s'ed the code.
