### PR TITLE
add oj to gemspec

### DIFF
--- a/hulse.gemspec
+++ b/hulse.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_dependency "httparty"
+  spec.add_dependency "oj"
 end


### PR DESCRIPTION
oj is actually a dependency, needs to be in the bundled dependencies.
