### PR TITLE
Fix date parsing errors and deprecation warnings

### DIFF
--- a/lib/hulse/bill.rb
+++ b/lib/hulse/bill.rb
@@ -85,8 +85,10 @@ module Hulse
     def self.get_latest_action(table)
       return [nil, nil] if table.css('tr').detect{|row| row.children[1].text == 'Latest Action:'}.children[3].children.first.text.strip == 'Action data to be retrieved.'
       return [nil, nil] if table.css('tr').detect{|row| row.children[1].text == 'Latest Action:'}.children[3].children.first.text.strip == 'There is no latest action for this bill'
-      text = table.css('tr').detect{|row| row.children[1].text == 'Latest Action:'}.children[3].children.first.text.split("(").first.strip
-      date = Date.parse(table.css('tr').detect{|row| row.children[1].text == 'Latest Action:'}.children[3].children.first.text, '%m/%d/%Y')
+      full_text = table.css('tr').detect{|row| row.children[1].text == 'Latest Action:'}.children[3].children.first.text
+      text = full_text.split("(").first.strip
+      date_str = full_text.scan(/\((\d+\/\d+\/\d+)\)/).first&.first
+      date = date_str ? Date.strptime(date_str, '%m/%d/%Y') : nil
       [text, date]
     end
 

--- a/test/house_vote_test.rb
+++ b/test/house_vote_test.rb
@@ -11,7 +11,7 @@ module Hulse
 
     def test_bill_url
       assert_equal @hv.bill_url, "https://www.congress.gov/bill/114th-congress/house-bill/1853"
-      assert_equal @sv.bill_url, nil
+      assert_nil @sv.bill_url
     end
 
   end

--- a/test/senate_vote_test.rb
+++ b/test/senate_vote_test.rb
@@ -11,7 +11,7 @@ module Hulse
 
     def test_bill_url
       assert_equal @sv.bill_url, "https://www.congress.gov/bill/114th-congress/senate-bill/754"
-      assert_equal @nv.bill_url, nil
+      assert_nil @nv.bill_url
     end
 
     def test_nomination


### PR DESCRIPTION
- Fix Date::Error in Bill.get_latest_action by using Date.strptime instead of Date.parse
- Extract date from text using regex pattern before parsing
- Handle cases where no date is present in the action text
- Replace assert_equal with nil with assert_nil to fix Minitest deprecation warnings